### PR TITLE
Fix manager access

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased] - 202x-xx-xx
 -------------------------
 
+Fixed
+~~~~~
+* manager access for instance subfunctions: `get_children`, `get_descendants`, `get_ancestors`, `get_family`, get_siblings`, `move_to`, `insert_at`
 
 [0.1.0] - 2023-04-29
 --------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Fixed
 ~~~~~
-* manager access for instance subfunctions: `get_children`, `get_descendants`, `get_ancestors`, `get_family`, get_siblings`, `move_to`, `insert_at`
+* manager access for instance subfunctions: `get_children`, `get_descendants`, `get_ancestors`, `get_family`, `get_siblings`, `move_to`, `insert_at`
 
 [0.1.0] - 2023-04-29
 --------------------

--- a/mptt2/models.py
+++ b/mptt2/models.py
@@ -120,7 +120,7 @@ class Node(Model):
         :type asc: bool
 
         """
-        children = self.objects.filter(ChildrenQuery(of=self))
+        children = self.__class__.objects.filter(ChildrenQuery(of=self))
         return children.order_by("-mptt_lft") if asc else children
 
     def get_descendants(self, include_self=False, asc=False) -> QuerySet:
@@ -133,7 +133,7 @@ class Node(Model):
         :type asc: bool
 
         """
-        descendants = self.objects.filter(
+        descendants = self.__class__.objects.filter(
             DescendantsQuery(of=self, include_self=include_self))
         return descendants.order_by("-mptt_lft") if asc else descendants
 
@@ -147,7 +147,7 @@ class Node(Model):
         :type asc: bool
 
         """
-        ancestors = self.objects.filter(
+        ancestors = self.__class__.objects.filter(
             AncestorsQuery(of=self, include_self=include_self))
         return ancestors.order_by("-mptt_lft") if asc else ancestors
 
@@ -161,7 +161,7 @@ class Node(Model):
         :type asc: bool
 
         """
-        family = self.objects.filter(FamilyQuery(
+        family = self.__class__.objects.filter(FamilyQuery(
             of=self, include_self=include_self))
         return family.order_by("-mptt_lft") if asc else family
 
@@ -175,13 +175,13 @@ class Node(Model):
         :type asc: bool
 
         """
-        siblings = self.objects.filter(
+        siblings = self.__class__.objects.filter(
             SiblingsQuery(of=self, include_self=include_self))
         return siblings.order_by("-mptt_lft") if asc else siblings
 
     def get_root(self):
         """returns the root node of the tree where this node is part of"""
-        return self.objects.get(RootQuery(of=self))
+        return self.__class__.objects.get(RootQuery(of=self))
 
     def move_to(self, target, position: Position = Position.LAST_CHILD):
         """Tree function to move a node relative to a given target by the given position
@@ -196,7 +196,7 @@ class Node(Model):
         :returns: the inserted node it self
         :rtype: :class:`mptt2.models.Node`
         """
-        return self.objects.move_node(
+        return self.__class__.objects.move_node(
             node=self,
             target=target,
             position=position
@@ -215,7 +215,7 @@ class Node(Model):
         :returns: the inserted node it self
         :rtype: :class:`mptt2.models.Node`
         """
-        return self.objects.insert_node(
+        return self.__class__.objects.insert_node(
             node=self,
             target=target,
             position=position

--- a/tests/tests_models.py
+++ b/tests/tests_models.py
@@ -7,6 +7,28 @@ class TestNodeModel(TestCase):
 
     fixtures = ["simple_nodes.json"]
 
+    def test_insert_root(self):
+        root_node: SimpleNode = SimpleNode()
+        root_node.insert_at(target=None)
+        root_pk = root_node.pk
+
+        self.assertGreater(root_pk, 0)
+        fetch_root = SimpleNode.objects.get(pk=root_pk)
+        self.assertIsNone(fetch_root.mptt_parent)
+
+    def test_insert_child(self):
+        root_node: SimpleNode = SimpleNode()
+        root_node.insert_at(target=None)
+        root_pk = root_node.pk
+
+        child_node: SimpleNode = SimpleNode()
+        child_node.insert_at(target=root_node)
+        child_pk = child_node.pk
+
+        self.assertGreater(child_pk, 0)
+        fetch_child = SimpleNode.objects.get(pk=child_pk)
+        self.assertEqual(fetch_child.mptt_parent.pk, root_pk)
+
     def test_delete(self):
         node: SimpleNode = SimpleNode.objects.get(pk=18)
         node.delete()


### PR DESCRIPTION
Fix for "AttributeError: Manager isn't accessible via {model} instances" error in all methods.

The correct manager access was already implemented for the tested delete method, but not for the other methods like insert_at.
This PR replaces all occurences of self.objects with self.__class__.objects and adds test for insert_at method.